### PR TITLE
Fix Kin8nm dataset downloading

### DIFF
--- a/bayesian_benchmarks/data.py
+++ b/bayesian_benchmarks/data.py
@@ -46,6 +46,7 @@ def normalize(X):
 
 class Dataset(object):
     def __init__(self, split=0, prop=0.9):
+
         if self.needs_download:
             self.download()
 
@@ -152,7 +153,7 @@ class Kin8nm(Dataset):
     url = 'http://mldata.org/repository/data/download/csv/csv_result-kin8nm'
     def read_data(self):
         data = pandas.read_csv(self.datapath, header=None).values
-        X_raw, Y_raw = data[1:, 1:-1], data[1:, -1].reshape(-1, 1)
+        X_raw, Y_raw = data[..., :-1], data[..., -1].reshape(-1, 1)
         assert X_raw.shape == (self.N, self.D)
         assert Y_raw.shape == (self.N, 1)
         return X_raw.astype(np.float), Y_raw.astype(np.float)

--- a/bayesian_benchmarks/data.py
+++ b/bayesian_benchmarks/data.py
@@ -83,7 +83,7 @@ class Dataset(object):
         return not os.path.isfile(self.datapath)
 
     def download(self):
-        logging.info('donwloading {} data'.format(self.name))
+        logging.info('downloading {} data'.format(self.name))
 
         is_zipped = np.any([z in self.url for z in ['.gz', '.zip', '.tar']])
 
@@ -103,7 +103,7 @@ class Dataset(object):
 
             # os.remove(filename)
 
-        logging.info('finished donwloading {} data'.format(self.name))
+        logging.info('finished downloading {} data'.format(self.name))
 
     def read_data(self):
         raise NotImplementedError
@@ -150,7 +150,26 @@ class Energy(Dataset):
 @add_regression
 class Kin8nm(Dataset):
     N, D, name = 8192, 8, 'kin8nm'
-    url = 'http://mldata.org/repository/data/download/csv/csv_result-kin8nm'
+    url = 'https://www.dcc.fc.up.pt/~ltorgo/Regression/kinematics.tar.gz'
+
+    @property
+    def datapath(self):
+        return os.path.join(self.datadir, 'Kinematics/kin8nm.data')
+
+    def download(self):
+        logging.info('downloading {} data'.format(self.name))
+
+        filename = os.path.join(self.datadir, self.url.split('/')[-1])
+        with urlopen(self.url) as response, open(filename, 'wb') as outfile:
+            data = response.read()
+            outfile.write(data)
+
+        import tarfile
+        with tarfile.open(filename, 'r:gz') as t:
+            t.extractall(path=self.datadir)
+
+        logging.info('finished downloading {} data'.format(self.name))
+
     def read_data(self):
         data = pandas.read_csv(self.datapath, header=None).values
         X_raw, Y_raw = data[..., :-1], data[..., -1].reshape(-1, 1)


### PR DESCRIPTION
The kin8nm dataset class was downloading from mldata.org, which now seems to be permanently defunct. These changes update the class to download from https://www.dcc.fc.up.pt/~ltorgo/Regression which has been a reliable and frequently cited source for the "LIACC regression" datasets, of which the kin8nm dataset is a member, for the past decade or more.